### PR TITLE
feat: add the `--host` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,12 @@ Available options:
     --disable-auto-open   Disable auto opening your browser
     --disable-reload      Disable live reloading
 -h, --help                help for gh-markdown-preview
+    --host string         Hostname this server will bind (default "localhost")
     --light-mode          Force light mode
 -p, --port int            TCP port number of this server (default 3333)
     --verbose             Show verbose output
     --version             Show the version
 ```
-
-![gh markdown-preview command](https://user-images.githubusercontent.com/10682/138411333-c1b5ccb9-d56a-478c-9f20-4c71cfe1536a.png)
 
 ## Related projects
 

--- a/cmd/browser.go
+++ b/cmd/browser.go
@@ -1,15 +1,13 @@
 package cmd
 
 import (
-	"fmt"
 	"os/exec"
 	"runtime"
 	"time"
 )
 
-func openBrowser(port int) error {
+func openBrowser(url string) error {
 	<-time.After(100 * time.Millisecond)
-	url := fmt.Sprintf("http://localhost:%d/", port)
 	var args []string
 	var cmd string
 	switch runtime.GOOS {

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -37,8 +37,10 @@ var rootCmd = &cobra.Command{
 
 		verbose, _ = cmd.Flags().GetBool("verbose")
 
+		host, _ := cmd.Flags().GetString("host")
 		port, _ := cmd.Flags().GetInt("port")
-		server := Server{port: port}
+
+		server := Server{host: host, port: port}
 
 		disableReload, _ := cmd.Flags().GetBool("disable-reload")
 		reload := true
@@ -76,6 +78,7 @@ func Execute() {
 
 func init() {
 	rootCmd.Flags().IntP("port", "p", 3333, "TCP port number of this server")
+	rootCmd.Flags().StringP("host", "", "localhost", "Hostname this server will bind")
 	rootCmd.Flags().BoolP("version", "", false, "Show the version")
 	rootCmd.Flags().BoolP("disable-reload", "", false, "Disable live reloading")
 	rootCmd.Flags().BoolP("disable-auto-open", "", false, "Disable auto opening your browser")


### PR DESCRIPTION
The user can specify the hostname the server will bind with a `--host` option. The default value is `localhost`.

Usage:

```
$ gh markdown-preview --host 192.168.3.3
```

Outputs:

```
2022/04/07 18:29:49 Accepting connections at http://192.168.3.3:3333/
2022/04/07 18:29:49 Open http://192.168.3.3:3333/ on your browser
```

If `locahost` is set, you can't access it from the other global address.