### PR TITLE
Correct the body width to match GitHub

### DIFF
--- a/cmd/template.html
+++ b/cmd/template.html
@@ -27,7 +27,7 @@
       .markdown-body {
         box-sizing: border-box;
         min-width: 200px;
-        max-width: 980px;
+        max-width: 920px;
         margin: 0 auto;
         padding: 45px;
       }


### PR DESCRIPTION
The body of the page content was rendering at 890px while on GitHub the body width was 830px.

Considering the padding, it appears that reducing the max-width on the html from 980px to 920px should resolve this.