### PR TITLE
ADD WSL route in browser auto open feature

### DIFF
--- a/cmd/browser.go
+++ b/cmd/browser.go
@@ -1,10 +1,42 @@
 package cmd
 
 import (
+	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"time"
 )
+
+type FileReader interface {
+	ReadFile(string) (string, error)
+}
+
+type ProcVersionReader struct{}
+
+func (r ProcVersionReader) ReadFile(filename string) (string, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func isContainWSL(data string) bool {
+	return strings.Contains(data, "WSL")
+}
+
+func isWSLWithReader(reader FileReader) bool {
+	data, err := reader.ReadFile("/proc/version")
+	if err != nil {
+		return false
+	}
+	return isContainWSL(data)
+}
+
+func isWSL() bool {
+	return isWSLWithReader(ProcVersionReader{})
+}
 
 func openBrowser(url string) error {
 	<-time.After(100 * time.Millisecond)
@@ -17,7 +49,12 @@ func openBrowser(url string) error {
 	case "darwin":
 		cmd = "open"
 	default: // "linux", "freebsd", "openbsd", "netbsd"
-		cmd = "xdg-open"
+		if isWSL() {
+			cmd = "cmd.exe"
+			args = []string{"/c", "start"}
+		} else {
+			cmd = "xdg-open"
+		}
 	}
 	args = append(args, url)
 	return exec.Command(cmd, args...).Start()

--- a/cmd/browser_test.go
+++ b/cmd/browser_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+)
+
+type MockFileReader struct {
+	content string
+	err     error
+}
+
+func (m MockFileReader) ReadFile(path string) (string, error) {
+	return m.content, m.err
+}
+
+func TestIsContainWSL(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     string
+		expected bool
+	}{
+		{
+			name:     "WSL Data",
+			data:     "Linux version 4.19.128-microsoft-standard (WSL2)",
+			expected: true,
+		},
+		{
+			name:     "Non-WSL Data",
+			data:     "Linux version 4.15.0-72-generic",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isContainWSL(tt.data)
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestIsWSL(t *testing.T) {
+	tests := []struct {
+		name     string
+		reader   FileReader
+		expected bool
+	}{
+		{
+			name:     "WSL Data",
+			reader:   MockFileReader{content: "Linux version 4.19.128-microsoft-standard (WSL2)"},
+			expected: true,
+		},
+		{
+			name:     "Non-WSL Data",
+			reader:   MockFileReader{content: "Linux version 4.15.0-72-generic"},
+			expected: false,
+		},
+		{
+			name:     "Read error",
+			reader:   MockFileReader{err: errors.New("read error")},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isWSLWithReader(tt.reader)
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Add

Support browser auto open feature on WSL.
Open url with default browser in windows side, when run in WSL.

# Fixed Probrem

Auto open browser feature is not working in using WSL.

# Description

## How to run in Windows side when launch in WSL

Run `cmd.exe` with full file name with extension.

Note: Run `powershell` in WSL is work in WSL, run `powershell.exe` in WSL is work in windows. This is WSL general behavior.

## How to check is running on WSL

This is list of provide information that can be used to determine the WSL environment.

- Content of `/proc/version`
  - In both WSL1 and WSL2, this information contains the strings "Microsoft" or "WSL". 
  -  Can definitively detect if you're operating within a WSL environment.
- Content of `/etc/os-release`
  - In WSL, this file might contain information specific to a particular WSL distribution.
  - It doesn't necessarily contain information that identifies WSL itself.
- Exists `/usr/lib/wsl` or not
  - This is work only WSL2
