### PR TITLE
Use `gfm` mode

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -44,7 +44,7 @@ func findReadme(dir string) (string, error) {
 }
 
 func toHTML(markdown string) (string, error) {
-	sout, _, err := gh("api", "-X", "POST", "/markdown", "-f", fmt.Sprintf("text=%s", markdown))
+	sout, _, err := gh("api", "-X", "POST", "/markdown", "-f", fmt.Sprintf("text=%s", markdown), "-f", "mode=gfm")
 	if err != nil {
 		return "", err
 	}

--- a/cmd/app_test.go
+++ b/cmd/app_test.go
@@ -85,3 +85,54 @@ func TestToHTML(t *testing.T) {
 		t.Errorf("got %v\n want %v", actual, expected)
 	}
 }
+
+func TestGfmCheckboxes(t *testing.T) {
+	string, err := slurp("../testdata/gfm-checkboxes.md")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	html, err := toHTML(string)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	actual := strings.TrimSpace(html)
+
+	checkBoxes := 0
+	checkedCheckBoxes := 0
+	uncheckedCheckBoxes := 0
+	for _, line := range strings.Split(actual, "\n") {
+		if strings.Contains(line, "<input type=\"checkbox\"") {
+			checkBoxes++
+			if strings.Contains(line, "checked") {
+				checkedCheckBoxes++
+			} else {
+				uncheckedCheckBoxes++
+			}
+		}
+	}
+	if checkBoxes != 2 {
+		t.Errorf("got %v checkboxes, want 2", checkBoxes)
+	}
+	if checkedCheckBoxes != 1 {
+		t.Errorf("got %v checked checkboxes, want 1", checkedCheckBoxes)
+	}
+	if uncheckedCheckBoxes != 1 {
+		t.Errorf("got %v unchecked checkboxes, want 1", uncheckedCheckBoxes)
+	}
+}
+
+func TestGfmAlerts(t *testing.T) {
+	string, err := slurp("../testdata/gfm-alerts.md")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	html, err := toHTML(string)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	actual := strings.TrimSpace(html)
+
+	if strings.Contains(actual, "<blockquote") {
+		t.Error("got blockquote tag instead of alerts")
+	}
+}

--- a/cmd/template.html
+++ b/cmd/template.html
@@ -2,11 +2,11 @@
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     {{ $cssURL :=
-    "https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.0.0/github-markdown.min.css" }} {{
+    "https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.6.1/github-markdown.min.css" }} {{
     if eq .Mode "dark" }} {{ $cssURL =
-    "https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.0.0/github-markdown-dark.min.css"
+    "https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.6.1/github-markdown-dark.min.css"
     }} {{ else if eq .Mode "light" }} {{ $cssURL =
-    "https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.0.0/github-markdown-light.min.css"
+    "https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.6.1/github-markdown-light.min.css"
     }}{{ end }}
     <link rel="stylesheet" href="{{ $cssURL }}" />
     <style>

--- a/testdata/gfm-alerts.md
+++ b/testdata/gfm-alerts.md
@@ -1,0 +1,14 @@
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+> [!TIP]
+> Helpful advice for doing things better or more easily.
+
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.

--- a/testdata/gfm-checkboxes.md
+++ b/testdata/gfm-checkboxes.md
@@ -1,0 +1,2 @@
+- [ ] Not done
+- [x] Done


### PR DESCRIPTION
Fixes #39, #50, #51

Since the aim of this plugin is to replicate the markdown rendering of GitHub.com, we should always have mode set to `gfm` when sending requests to github.

This allows us to render checkboxes, alerts and other things exclusive to gfm.