### PR TITLE
feat: Add support for Mermaid diagrams

### DIFF
--- a/cmd/template.html
+++ b/cmd/template.html
@@ -86,7 +86,7 @@
               MathJax.typeset();
             });
             $('div.highlight-source-mermaid > pre').each(function(i, pre) {
-              pre.innerHTML = pre.innerText;
+              pre.textContent = pre.textContent;
             });
 
             {{ if eq .Mode "dark" }}
@@ -98,8 +98,8 @@
             {{ end }}
             mermaid.initialize({ startOnLoad: false, theme: mermaidJsTheme });
             mermaid.run({
-                querySelector: 'div.highlight-source-mermaid > pre',
-              });
+              querySelector: 'div.highlight-source-mermaid > pre',
+            });
           })}
         })
       };

--- a/cmd/template.html
+++ b/cmd/template.html
@@ -92,9 +92,9 @@
             {{ if eq .Mode "dark" }}
               const mermaidJsTheme = 'dark';
             {{ else if eq .Mode "light" }}
-              const mermaidJsTheme = 'neutral';
+              const mermaidJsTheme = 'default';
             {{ else }}
-              const mermaidJsTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'neutral';
+              const mermaidJsTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'default';
             {{ end }}
             mermaid.initialize({ startOnLoad: false, theme: mermaidJsTheme });
             mermaid.run({

--- a/cmd/template.html
+++ b/cmd/template.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -83,7 +84,22 @@
                 }
               }
               MathJax.typeset();
-            })
+            });
+            $('div.highlight-source-mermaid > pre').each(function(i, pre) {
+              pre.innerHTML = pre.innerText;
+            });
+
+            {{ if eq .Mode "dark" }}
+              const mermaidJsTheme = 'dark';
+            {{ else if eq .Mode "light" }}
+              const mermaidJsTheme = 'neutral';
+            {{ else }}
+              const mermaidJsTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'neutral';
+            {{ end }}
+            mermaid.initialize({ startOnLoad: false, theme: mermaidJsTheme });
+            mermaid.run({
+                querySelector: 'div.highlight-source-mermaid > pre',
+              });
           })}
         })
       };
@@ -111,6 +127,7 @@
         loadmd();
       })()
     </script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/10.9.1/mermaid.min.js"></script>
     <article id="markdown-body" class="markdown-body"></article>
   </body>
 </html>


### PR DESCRIPTION
Fixes #45

This PR adds support for Mermaid diagrams and charts.

The way GitHub.com renders mermaid blocks [is not simple](https://mermaid.js.org/) and it involves injecting an iframe. Imo, it doesn't make sense to use the same mechanism (if at all possible) for our plugin. Instead, we are importing the [mermaidjs](https://mermaid.js.org/) library and using it to convert all mermaid code blocks into SVGs. So, the rendered chart is the exact same but our implementation lacks some UI niceties like zoom in/zoom out buttons, etc, which I think is a fair trade-off.

Here's a comparison:

#### Rendered on GitHub
```mermaid
graph TB
  SubGraph1 --> SubGraph1Flow

  subgraph "SubGraph 1 Flow"
    SubGraph1Flow(SubNode 1)
    SubGraph1Flow -- Choice1 --> DoChoice1
    SubGraph1Flow -- Choice2 --> DoChoice2
  end

  subgraph "Main Graph"
    Node1[Node 1] --> Node2[Node 2]
    Node2 --> SubGraph1[Jump to SubGraph1]
    SubGraph1 --> FinalThing[Final Thing]
  end
```

#### Rendered by us

- Light Mode

![image](https://github.com/user-attachments/assets/b9e86f94-47c0-4b24-b59d-e3a49c48ccbc)

- Dark Mode

![image](https://github.com/user-attachments/assets/c452a210-9cce-42c5-a7ef-a9b2e2ad3a9d)
