### PR TITLE
feat: Add `--markdown-mode` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Available options:
 
 ```text
     --dark-mode           Force dark mode
+    --markdown-mode       Force "markdown" mode (rather than default "gfm")
     --disable-auto-open   Disable auto opening your browser
     --disable-reload      Disable live reloading
 -h, --help                help for gh-markdown-preview

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -43,8 +43,12 @@ func findReadme(dir string) (string, error) {
 	return "", err
 }
 
-func toHTML(markdown string) (string, error) {
-	sout, _, err := gh("api", "-X", "POST", "/markdown", "-f", fmt.Sprintf("text=%s", markdown), "-f", "mode=gfm")
+func toHTML(markdown string, param *Param) (string, error) {
+	mode := "gfm"
+	if param.markdownMode {
+		mode = "markdown"
+	}
+	sout, _, err := gh("api", "-X", "POST", "/markdown", "-f", fmt.Sprintf("text=%s", markdown), "-f", fmt.Sprintf("mode=%s", mode))
 	if err != nil {
 		return "", err
 	}

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -14,6 +14,7 @@ var verbose = false
 
 type Param struct {
 	filename       string
+	markdownMode   bool
 	reload         bool
 	forceLightMode bool
 	forceDarkMode  bool
@@ -52,6 +53,8 @@ var rootCmd = &cobra.Command{
 		forceLightMode, _ := cmd.Flags().GetBool("light-mode")
 		forceDarkMode, _ := cmd.Flags().GetBool("dark-mode")
 
+		markdownMode, _ := cmd.Flags().GetBool("markdown-mode")
+
 		disableAutoOpen, _ := cmd.Flags().GetBool("disable-auto-open")
 		autoOpen := true
 		if disableAutoOpen {
@@ -60,6 +63,7 @@ var rootCmd = &cobra.Command{
 
 		param := &Param{
 			filename:       filename,
+			markdownMode:   markdownMode,
 			reload:         reload,
 			forceLightMode: forceLightMode,
 			forceDarkMode:  forceDarkMode,
@@ -85,6 +89,7 @@ func init() {
 	rootCmd.Flags().StringP("host", "", "localhost", "Hostname this server will bind")
 	rootCmd.Flags().BoolP("version", "", false, "Show the version")
 	rootCmd.Flags().BoolP("disable-reload", "", false, "Disable live reloading")
+	rootCmd.Flags().BoolP("markdown-mode", "", false, "Force \"markdown\" mode (rather than default \"gfm\")")
 	rootCmd.Flags().BoolP("disable-auto-open", "", false, "Disable auto opening your browser")
 	rootCmd.Flags().BoolP("verbose", "", false, "Show verbose output")
 	rootCmd.Flags().BoolP("light-mode", "", false, "Force light mode")


### PR DESCRIPTION
Fixes https://github.com/yusukebe/gh-markdown-preview/issues/60. This change adds the new `--markdown-mode` boolean option, which allows users to force output to be rendered in `markdown` mode[1], rather than in the default `gfm` mode.

[1] https://docs.github.com/en/rest/markdown/markdown#render-a-markdown-document--parameters