### PR TITLE
feat: Add ELK layout support for Mermaid diagrams

### DIFF
--- a/cmd/template.html
+++ b/cmd/template.html
@@ -219,10 +219,12 @@
         loadmd();
       })()
     </script>
-    <script
-      type="text/javascript"
-      src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/11.3.0/mermaid.min.js"
-    ></script>
+    <script type="module">
+      import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+      import elkLayouts from 'https://cdn.jsdelivr.net/npm/@mermaid-js/layout-elk@0/dist/mermaid-layout-elk.esm.min.mjs';
+      mermaid.registerLayoutLoaders(elkLayouts);
+      window.mermaid = mermaid;
+    </script>
     <article id="markdown-body" class="markdown-body"></article>
   </body>
 </html>


### PR DESCRIPTION
- Import Mermaid v11 ES module with ELK layout loaders
  - Use [Mermaid Official CDN](https://mermaid.js.org/config/usage.html)
  - Consultation required: If you want to stay at 11.3.0
- Register [ELK layouts](https://mermaid.js.org/intro/syntax-reference.html#supported-layout-algorithms) using registerLayoutLoaders()
- Minimal change (4 lines) to enable 'layout: elk' configuration
- Maintains compatibility with existing Dagre layout (default)
- Supports advanced layout options for complex diagrams
