### PR TITLE
feat: Support preview markdown from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ Or this command will detect README file in the directory automatically.
 gh markdown-preview
 ```
 
+You can also preview Markdown from stdin by piping or using `-`:
+
+```
+echo "# Hello" | gh markdown-preview
+cat README.md | gh markdown-preview
+gh markdown-preview - < README.md
+```
+
 Then access the local web server such as `http://localhost:3333` with Chrome, Firefox, or Safari.
 
 Available options:

--- a/cmd/app_test.go
+++ b/cmd/app_test.go
@@ -75,7 +75,7 @@ func TestGh(t *testing.T) {
 
 func TestToHTML(t *testing.T) {
 	markdown := "text"
-	html, err := toHTML(markdown)
+	html, err := toHTML(markdown, &Param{})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -91,7 +91,7 @@ func TestGfmCheckboxes(t *testing.T) {
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	html, err := toHTML(string)
+	html, err := toHTML(string, &Param{})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -126,7 +126,7 @@ func TestGfmAlerts(t *testing.T) {
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	html, err := toHTML(string)
+	html, err := toHTML(string, &Param{})
 	if err != nil {
 		t.Errorf(err.Error())
 	}

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -43,7 +43,8 @@ func TestHandler(t *testing.T) {
 
 func TestMdHandler(t *testing.T) {
 	filename := "../testdata/markdown-demo.md"
-	ts := httptest.NewServer(mdHandler(filename))
+	param := &Param{reload: false}
+	ts := httptest.NewServer(mdHandler(filename, param))
 	defer ts.Close()
 
 	res, err := http.Get(ts.URL)


### PR DESCRIPTION
Hi @yusukebe!

Thank you for the very useful tool.
I added support of reading markdown from stdin.

There are some tools which output markdown expected to be rendered in Github.
For example, GitHub provides generate release notes content API which generate release notes markdown. 
https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#generate-release-notes-content-for-a-release

It would be handy if we can use gh-markdown-preview to preview such markdown just by piping output into gh-markdown-preview.